### PR TITLE
[REFACTOR] 상품 크롤링 백그라운드 처리

### DIFF
--- a/scripts/crawl_29cm.py
+++ b/scripts/crawl_29cm.py
@@ -207,10 +207,11 @@ def crawl_product_details(url):
         result['shoppingmall_name'] = "29CM"
 
         # 2. 상품 URL
-        result['product_url'] = url
+        final_url = driver.current_url
+        result['product_url'] = final_url
 
         # 3. 상품 번호 추출
-        product_num = extract_product_num(url)
+        product_num = extract_product_num(final_url)
         result['product_num'] = product_num
 
         # 4. 카테고리 추출
@@ -403,9 +404,13 @@ def crawl_product_details(url):
         print(f"크롤링 중 오류 발생: {str(e)}")
         import traceback
         traceback.print_exc()
-        # 예외 발생 시에도 product_num 추출 시도
-        product_num = extract_product_num(url)
-        return {"shoppingmall_name": "29CM", "product_url": url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
+        # 예외 발생 시 리다이렉트된 URL 우선 사용, 없으면 요청 URL 사용
+        try:
+            fallback_url = driver.current_url
+        except Exception:
+            fallback_url = url
+        product_num = extract_product_num(fallback_url)
+        return {"shoppingmall_name": "29CM", "product_url": fallback_url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
 
     finally:
         driver.quit()

--- a/scripts/crawl_musinsa.py
+++ b/scripts/crawl_musinsa.py
@@ -99,10 +99,11 @@ def crawl_product_details(url):
         result['shoppingmall_name'] = "무신사"
         
         # 2. 상품 URL
-        result['product_url'] = url
+        final_url = driver.current_url
+        result['product_url'] = final_url
         
         # 3. 상품 번호 추출
-        product_num = extract_product_num(url)
+        product_num = extract_product_num(final_url)
         result['product_num'] = product_num
         
         # 4. 카테고리 추출
@@ -210,9 +211,13 @@ def crawl_product_details(url):
         
     except Exception as e:
         print(f"크롤링 중 오류 발생: {str(e)}")
-        # 예외 발생 시에도 product_num 추출 시도
-        product_num = extract_product_num(url)
-        return {"shoppingmall_name": "무신사", "product_url": url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
+        # 예외 발생 시 리다이렉트된 URL 우선 사용, 없으면 요청 URL 사용
+        try:
+            fallback_url = driver.current_url
+        except Exception:
+            fallback_url = url
+        product_num = extract_product_num(fallback_url)
+        return {"shoppingmall_name": "무신사", "product_url": fallback_url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
         
     finally:
         driver.quit()

--- a/scripts/crawl_wconcept.py
+++ b/scripts/crawl_wconcept.py
@@ -110,10 +110,11 @@ def crawl_product_details(url):
         result['shoppingmall_name'] = "W컨셉"
 
         # 2. 상품 URL
-        result['product_url'] = url
+        final_url = driver.current_url
+        result['product_url'] = final_url
 
         # 3. 상품 번호 추출
-        product_num = extract_product_num(url)
+        product_num = extract_product_num(final_url)
         result['product_num'] = product_num
 
         # 4. 카테고리 추출
@@ -255,9 +256,13 @@ def crawl_product_details(url):
         print(f"크롤링 중 오류 발생: {str(e)}")
         import traceback
         traceback.print_exc()
-        # 예외 발생 시에도 product_num 추출 시도
-        product_num = extract_product_num(url)
-        return {"shoppingmall_name": "W컨셉", "product_url": url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
+        # 예외 발생 시 리다이렉트된 URL 우선 사용, 없으면 요청 URL 사용
+        try:
+            fallback_url = driver.current_url
+        except Exception:
+            fallback_url = url
+        product_num = extract_product_num(fallback_url)
+        return {"shoppingmall_name": "W컨셉", "product_url": fallback_url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
 
     finally:
         driver.quit()

--- a/scripts/crawl_zigzag.py
+++ b/scripts/crawl_zigzag.py
@@ -114,10 +114,11 @@ def crawl_product_details(url):
         result['shoppingmall_name'] = "지그재그"
 
         # 2. 상품 URL
-        result['product_url'] = url
+        final_url = driver.current_url
+        result['product_url'] = final_url
 
         # 3. 상품 번호 추출
-        product_num = extract_product_num(url)
+        product_num = extract_product_num(final_url)
         result['product_num'] = product_num
 
         # 4. 대표 이미지 추출
@@ -213,9 +214,13 @@ def crawl_product_details(url):
         print(f"크롤링 중 오류 발생: {str(e)}")
         import traceback
         traceback.print_exc()
-        # 예외 발생 시에도 product_num 추출 시도
-        product_num = extract_product_num(url)
-        return {"shoppingmall_name": "지그재그", "product_url": url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
+        # 예외 발생 시 리다이렉트된 URL 우선 사용, 없으면 요청 URL 사용
+        try:
+            fallback_url = driver.current_url
+        except Exception:
+            fallback_url = url
+        product_num = extract_product_num(fallback_url)
+        return {"shoppingmall_name": "지그재그", "product_url": fallback_url, "product_num": product_num, "category": "-", "product_img_url": "-", "product_name": "-", "brand_name": "-", "price": "-", "star_point": None, "AI_review": None}
 
     finally:
         driver.quit()


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #33

## ✨ 작업 개요
> 백엔드 레포 112번 PR과 함께 머지해야 합니다!
상품 크롤링을 백그라운드에서 돌립니다.
상품 URL 저장을 리다이렉트가 필요한 URL(원클릭 링크, 공유코드 링크 등)이면 리다이렉트 처리하여 저장합니다.
DB에 상품이 중복으로 들어가는 것을 방지하기 위해 unique를 추가합니다.
분명 상품번호로 상품이 중복 저장되지 않게 관리하고 있는데.. 제미나이와 함께 토론해 봐도 뭐가 문제인지 모르겠습니다(절규)

## 📷 이미지 첨부 (선택)
<img width="1587" height="808" alt="image" src="https://github.com/user-attachments/assets/b81047be-8347-43b6-b56a-f5eaa3600f12" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.